### PR TITLE
Move assets to https

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -8,12 +8,12 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
 	<meta name="robots" content="index, follow">
-	<script type="text/javascript" src="http://code.jquery.com/jquery-2.1.0.min.js"></script>
+	<script type="text/javascript" src="https://code.jquery.com/jquery-2.1.0.min.js"></script>
 	<script src="{{site.baseurl}}/js/highlight.pack.js"></script>
 	<script src="{{site.baseurl}}/js/ustream-embedapi.min.js"></script>
 	<script src="{{site.baseurl}}/js/apidocs.js"></script>
 	<link rel="canonical" href="http://developers.video.ibm.com{{ page.url }}"/>
-	<link href='http://fonts.googleapis.com/css?family=Open+Sans:400,600,700,300' rel='stylesheet' type='text/css'>
+	<link href='https://fonts.googleapis.com/css?family=Open+Sans:400,600,700,300' rel='stylesheet' type='text/css'>
 	<link rel="stylesheet" href="https://ustvstaticcdn2-a.akamaihd.net/v5/css/reset.css" type="text/css" media="screen">
 	<link rel="stylesheet" href="{{site.baseurl}}/css/snorky_46.0.css" type="text/css" media="screen">
 	<link rel="stylesheet" href="{{site.baseurl}}/css/helvetica-for-ibm.css" type="text/css" media="screen">


### PR DESCRIPTION
The api docs site is available under HTTPS as well, so we need to move all external assets under HTTPS. 