### PR TITLE
docs(responsive embed): add missing attributes

### DIFF
--- a/_posts/2015-11-17-player-responsive-embed.html
+++ b/_posts/2015-11-17-player-responsive-embed.html
@@ -27,6 +27,8 @@ categoryItemLabel:
 	&lt;iframe id="UstreamIframe"
 		width="100%" height="100%"
 		src="https://www.ustream.tv/embed/1524"
+		allowfullscreen
+		webkitallowfullscreen
 		frameborder="0"
 		style="position:absolute; top:0; left: 0"&gt;&lt;/iframe&gt;
 &lt;/div&gt;</code></pre>


### PR DESCRIPTION
- fullscreen allowed attributes added to iframe example